### PR TITLE
changed test

### DIFF
--- a/packages/Spellcheck-Tests.package/PluggableTextMorphPlusTests.class/instance/setUp.st
+++ b/packages/Spellcheck-Tests.package/PluggableTextMorphPlusTests.class/instance/setUp.st
@@ -1,6 +1,6 @@
 as yet unclassified
 setUp
 	pluggableTextMorphPlus := PluggableTextMorphPlus new.
-	pluggableTextMorphPlus textMorph contents: 'This is a tset.'.
+	pluggableTextMorphPlus setText: 'This is a tset.'.
 	pluggableTextMorphPlus styler: SpellingTextStyler new.
 	pluggableTextMorphPlus textMorph editor selectFrom:11 to: 14.

--- a/packages/Spellcheck-Tests.package/PluggableTextMorphPlusTests.class/instance/testMenuWithSpellingAtTop.st
+++ b/packages/Spellcheck-Tests.package/PluggableTextMorphPlusTests.class/instance/testMenuWithSpellingAtTop.st
@@ -1,9 +1,7 @@
 as yet unclassified
 testMenuWithSpellingAtTop
-	| menu spellChecker selection topSuggestion |
+	| menu |
 	menu := pluggableTextMorphPlus getMenuWithSpellcheckingAtTop:  (MenuMorph new defaultTarget: pluggableTextMorphPlus model).
-	selection := pluggableTextMorphPlus textMorph editor selection string.
-	spellChecker := SpellChecker new.
-	topSuggestion := (spellChecker suggestionsFor: selection) first.
-	self assert: ((menu items collect: [:item | item contents]) includes: topSuggestion).
+	"We used the workspace to find out that a suggestion for the selected word is 'test'"
+	self assert: ((menu items collect: [:item | item contents]) includes: 'test').
 	self assert: ((menu items collect: [:item | item contents]) includes: 'add to dictionary').

--- a/packages/Spellcheck-Tests.package/PluggableTextMorphPlusTests.class/methodProperties.json
+++ b/packages/Spellcheck-Tests.package/PluggableTextMorphPlusTests.class/methodProperties.json
@@ -3,4 +3,4 @@
 		 },
 	"instance" : {
 		"setUp" : "RS 5/27/2018 16:00:29",
-		"testMenuWithSpellingAtTop" : "RS 5/27/2018 16:51:49" } }
+		"testMenuWithSpellingAtTop" : "RS 5/29/2018 11:30:09" } }

--- a/packages/Spellcheck-Tests.package/PluggableTextMorphPlusTests.class/methodProperties.json
+++ b/packages/Spellcheck-Tests.package/PluggableTextMorphPlusTests.class/methodProperties.json
@@ -2,5 +2,5 @@
 	"class" : {
 		 },
 	"instance" : {
-		"setUp" : "RS 5/27/2018 16:00:29",
+		"setUp" : "RS 5/29/2018 22:33:05",
 		"testMenuWithSpellingAtTop" : "RS 5/29/2018 11:30:09" } }


### PR DESCRIPTION
**1.** I removed the logic from the test (as explained in todays lecture), because it was the same logic that we were also using in our spellchecker (we would only assert both calculations have the same result, but they both could be wrong).
Now we are hardcoding the word that we expect.
**Fun Fact:** 
NASA did the same mistake when calibrating the mirror of the Hubble telescope which led to blurry images.

**2.** I also fixed the problem that the tests did not pass in Squeak 5.0:
This was the case because in Squeak 5.0 the `textMorph` was not initialized (but it was in 5.1).
Because I've tried to set the content of `textMorph` directly, it crashed. Now I use `setText:` which initializes `textMorph` if it is `nil` (in 5.0)