### PR TITLE
It is now possible to give a whole text to the ui and to handle every…

### DIFF
--- a/packages/Spellcheck-Core.package/SpellcheckCorrectionUI.class/instance/addToDict.st
+++ b/packages/Spellcheck-Core.package/SpellcheckCorrectionUI.class/instance/addToDict.st
@@ -1,5 +1,5 @@
 as yet unclassified
 addToDict
 
-	SpellChecker instance addWordToDictionary: wrongWordText.
-	self clear
+	SpellChecker instance addWordToDictionary: currentWord.
+	self next

--- a/packages/Spellcheck-Core.package/SpellcheckCorrectionUI.class/instance/clear.st
+++ b/packages/Spellcheck-Core.package/SpellcheckCorrectionUI.class/instance/clear.st
@@ -1,5 +1,7 @@
 as yet unclassified
 clear
 
+
 	self wrongWordText: 'No spell checking errror'.
-	self alternatives: #(#'---')
+	self alternatives: #(#'---').
+	inputText := ''

--- a/packages/Spellcheck-Core.package/SpellcheckCorrectionUI.class/instance/ignore.st
+++ b/packages/Spellcheck-Core.package/SpellcheckCorrectionUI.class/instance/ignore.st
@@ -1,4 +1,4 @@
 as yet unclassified
 ignore
-
-	self clear
+	
+	self next

--- a/packages/Spellcheck-Core.package/SpellcheckCorrectionUI.class/instance/inputText..st
+++ b/packages/Spellcheck-Core.package/SpellcheckCorrectionUI.class/instance/inputText..st
@@ -1,0 +1,8 @@
+as yet unclassified
+inputText: aText
+
+	inputText := aText.
+	wrongWords := SpellChecker instance mistakenWordsIn: aText string.
+	currentKey := wrongWords keys detect: [ :a | true ] ifNone: [self clear. ^self]. "gets first element"
+	self wrongWordText: (aText string copyFrom: currentKey to: (wrongWords at: currentKey))
+	

--- a/packages/Spellcheck-Core.package/SpellcheckCorrectionUI.class/instance/next.st
+++ b/packages/Spellcheck-Core.package/SpellcheckCorrectionUI.class/instance/next.st
@@ -1,0 +1,7 @@
+as yet unclassified
+next
+
+	inputText ~= '' ifTrue: [
+		wrongWords removeKey: currentKey.
+		currentKey := wrongWords keys detect: [ :a | true ] ifNone: [self clear. ^self]. "gets first element"
+		self wrongWordText: (inputText string copyFrom: currentKey to: (wrongWords at: currentKey))]

--- a/packages/Spellcheck-Core.package/SpellcheckCorrectionUI.class/instance/selectedAlternativeIndex..st
+++ b/packages/Spellcheck-Core.package/SpellcheckCorrectionUI.class/instance/selectedAlternativeIndex..st
@@ -1,6 +1,8 @@
 as yet unclassified
 selectedAlternativeIndex: anIndex
 	anIndex = 0 ifTrue: [^self].
-	Transcript show: (self alternatives at: anIndex).
-	selectedIndex := anIndex.
-	self changed: #selectedAlternativeIndex.
+	inputText replaceFrom: currentKey to: (wrongWords at: currentKey) with: (self alternatives at: anIndex).
+	Transcript show: inputText.
+	self next.
+	"selectedIndex := anIndex."
+	"self changed: #selectedAlternativeIndex."

--- a/packages/Spellcheck-Core.package/SpellcheckCorrectionUI.class/instance/wrongWordText..st
+++ b/packages/Spellcheck-Core.package/SpellcheckCorrectionUI.class/instance/wrongWordText..st
@@ -1,6 +1,6 @@
 as yet unclassified
-wrongWordText: aText
+wrongWordText: aString
 	
-	wrongWordText := aText.
-	self alternatives: (SpellChecker instance suggestionsFor: wrongWordText).
+	currentWord := aString.
+	self alternatives: (SpellChecker instance suggestionsFor: currentWord).
 	self changed: #wrongWordText

--- a/packages/Spellcheck-Core.package/SpellcheckCorrectionUI.class/instance/wrongWordText.st
+++ b/packages/Spellcheck-Core.package/SpellcheckCorrectionUI.class/instance/wrongWordText.st
@@ -1,4 +1,4 @@
 as yet unclassified
 wrongWordText
 
-	^ wrongWordText
+	^ currentWord

--- a/packages/Spellcheck-Core.package/SpellcheckCorrectionUI.class/methodProperties.json
+++ b/packages/Spellcheck-Core.package/SpellcheckCorrectionUI.class/methodProperties.json
@@ -2,16 +2,18 @@
 	"class" : {
 		 },
 	"instance" : {
-		"addToDict" : "ow 6/1/2018 13:44:16",
+		"addToDict" : "ow 6/5/2018 11:58:46",
 		"alternatives" : "ow 6/1/2018 11:22:08",
 		"alternatives:" : "ow 6/1/2018 13:42:46",
 		"buildWith:" : "RS 6/3/2018 15:54:44",
-		"clear" : "ow 6/1/2018 11:27:04",
-		"ignore" : "ow 6/1/2018 11:27:22",
+		"clear" : "ow 6/5/2018 11:59:48",
+		"ignore" : "ow 6/5/2018 12:06:38",
 		"ignoreAll" : "ow 6/1/2018 11:27:35",
 		"initialize" : "ow 6/1/2018 11:27:14",
+		"inputText:" : "ow 6/5/2018 12:00:46",
+		"next" : "ow 6/5/2018 12:05:43",
 		"open" : "pz 5/29/2018 21:55:12",
 		"selectedAlternativeIndex" : "RS 6/3/2018 16:06:05",
-		"selectedAlternativeIndex:" : "RS 6/3/2018 16:06:01",
-		"wrongWordText" : "ow 6/1/2018 11:22:39",
-		"wrongWordText:" : "ow 6/1/2018 13:43:02" } }
+		"selectedAlternativeIndex:" : "ow 6/5/2018 12:11:56",
+		"wrongWordText" : "ow 6/5/2018 11:29:45",
+		"wrongWordText:" : "ow 6/5/2018 11:29:56" } }

--- a/packages/Spellcheck-Core.package/SpellcheckCorrectionUI.class/properties.json
+++ b/packages/Spellcheck-Core.package/SpellcheckCorrectionUI.class/properties.json
@@ -6,7 +6,10 @@
 		 ],
 	"commentStamp" : "",
 	"instvars" : [
-		"wrongWordText",
+		"inputText",
+		"wrongWords",
+		"currentWord",
+		"currentKey",
 		"alternatives",
 		"selectedIndex" ],
 	"name" : "SpellcheckCorrectionUI",


### PR DESCRIPTION
… mistake individually.

BUT: When choosing a correct alternative for a wrong word, that word is just changed in the local copy of the text. The textMorph (e.g. the workspace) should be given to the ui so that we can extract and write back the contents directly